### PR TITLE
Update to support latest env var syntax

### DIFF
--- a/lib/secret_garden.rb
+++ b/lib/secret_garden.rb
@@ -37,7 +37,7 @@ module SecretGarden
   end
 
   def self.map
-    @map ||= SecretGarden::Map.new root: secret_file_path, env: env
+    @map ||= SecretGarden::Map.new root: secret_file_path
   end
 
   def self.secret_file_path=(val)
@@ -46,12 +46,4 @@ module SecretGarden
   def self.secret_file_path
     @secret_file_path ||= Dir.pwd
   end
-
-  def self.env=(val)
-    @env = val
-  end
-  def self.env
-    @env ||= 'development'  # sane default?
-  end
-
 end

--- a/lib/secret_garden/map.rb
+++ b/lib/secret_garden/map.rb
@@ -6,7 +6,7 @@ module SecretGarden
 
     attr_accessor :root
 
-    def initialize(root: Dir.pwd, env: nil)
+    def initialize(root: Dir.pwd)
       self.root = root
     end
 
@@ -37,7 +37,9 @@ module SecretGarden
 
     def parse_secret(line)
       name, path, property = line.scan(/([^\s]+)\s+([^:]+)(:.*)?/).first
-      path.gsub! /@ENV@/, SecretGarden.env
+      path.gsub!(/\$(?:([a-zA-Z_][a-zA-Z0-9_]*)|{([a-zA-Z_][a-zA-Z0-9_]*)})/) do
+        ENV.fetch($1 || $2)
+      end
       [name, path, property.to_s[1..-1]]
     end
   end


### PR DESCRIPTION
@devTristan convinced me that `Secretfile` should support arbitrary
environment variables, so I updated emk/credentials to support this,
using a more Unix-like syntax:

```
$VAULT_ENV
${VAULT_ENV}
```

The latter is useful when the variable appears in the middle of
something looks like an identifier:

```
secrets/${VAULT_ENV}_postgresql
```

There are some other subtle enhancements to the format, but this is the
only one that might break compatibility.

If possible, could you please merge this (with any appropriate tweaks)
before your gem gets publically announced?
